### PR TITLE
Alternative layout names

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -319,21 +319,33 @@ A single name given to the layout by the platform.
 Syntax
 
 ```xml
-<name value="..">  
+<name value=".." [type="{usage}"] />
 ```
 
 _Attribute:_ `value` (required)
 
 > The name of the layout.
 
+_Attribute:_ `type` (optional)
+
+> This attribute indicates the context of an alternative name. Valid values are: 
+> 
+> `layout` The `value` attribute describes the layout pattern, such as QWERTY, INSCRIPT, etc. typically used to distinguish various layouts of the same language. 
+> 
+> `indicator` The `value` attribute describes a short string to be used in currently selected layout indicator, such as US, SI9 etc. 
+> 
+> `normalization` The `value` attribute describes the intended normalization form of the keyboard layout output, and can be either `C`, `D` or `mixed`. The default value is `C`. 
+
 Example
 
 ```xml
-<keyboard locale="bg-t-k0-windows-phonetic-trad">
+<keyboard locale="el-Latn-t-k0-windows-el220">
     …
-    <names>
-        <name value="Bulgarian (Phonetic Traditional)" />
-    </names>
+    <names> 
+        <name value="Greek (220) Latin" /> 
+        <name type="layout" value="QWERTY" /> 
+        <name type="indicator" value="220L" /> 
+    </names> 
     …
 </keyboard>
 ```

--- a/keyboards/dtd/ldmlKeyboard.dtd
+++ b/keyboards/dtd/ldmlKeyboard.dtd
@@ -34,6 +34,8 @@ Except as contained in this notice, the name of a copyright holder shall not be 
 <!ELEMENT names ( name+ ) >
 
 <!ELEMENT name EMPTY >
+<!ATTLIST name type CDATA #IMPLIED > 
+    <!--@MATCH:literal/layout, indicator, normalization--> 
 <!ATTLIST name value CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->


### PR DESCRIPTION
Platforms may display hint to the users at various places as to what to expect from particular layout. For example, the layout of the name “United States-Dvorak for left hand” on Windows also uses “DVORAK L” description in the settings and “DVL” description in the input method list and notification area. These descriptions are independent of the layout name and commonly shared across different layouts, other example values are “QWERTZ” or “INSCRIPT”. 

**Proposed solution**

Add `type` attribute with context semantic to the `<name>` element:

```xml
<names> 
    <name value="Greek (220) Latin" /> 
    <name type="layout" value="QWERTY" /> 
    <name type="indicator" value="220L" /> 
</names> 
```

This allows for localization, but establishes one system name per layout file relationship (i.e. alternative name does not indicate to which `name` element it belongs, should there be multiple). All keyboard layouts currently in the CLDR have single `name` per layout. Multiple `name`s are allowed, but the specification does not elaborate on when that would be the case.

**Normalization indicator**
Some keyboard layouts might want to indicate an intended normalization to aid the user to select which keyboard layout to use. This is only a descriptive attribute to be used in the UI to disambiguate keyboard layouts for the user and does not affect validity of the layout data.

The proposed `name` extension above allows for this indication easily, by introducing `type="normalization"` name.